### PR TITLE
Move to stable hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ authors = [
 
 [dependencies]
 futures = "0.1.10"
+hyper = "0.11.0"
 quick-error = "1.1.0"
 serde = "0.9.5"
 serde_derive = "0.9.5"
 serde_json = "0.9.4"
 tokio-core = "0.1.4"
-
-[dependencies.hyper]
-git = "https://github.com/hyperium/hyper/"
+url = "1.4.0"
 
 [dev-dependencies]
 lazy_static = "0.2.2"


### PR DESCRIPTION
The hyper crate goes through some big refactoring lately. `Url` was removed in favor of `Uri`. See the commits [here](https://github.com/hyperium/hyper/issues/1089#issuecomment-286252505) and [here](https://github.com/hyperium/hyper/pull/1100). This means, handling Urls needs to be adjusted. This also includes error handling (`ParseError` becomes `UriError`). I've went ahead and  added the url dependency back to make this crate compile again.

Fair warning: the unit tests don't pass, but that is probably because of the missing InfluxDB for the integration tests. I tested against a live InfluxDB and it works as expected.

```
running 10 tests
test query_nonexistent_db ... ignored
test multiple_queries_to_nonexistent_database ... FAILED
thread panicked while panicking. aborting.
error: process didn't exit successfully: `/.../influxdb-rs/target/debug/deps/basic-dc19e4820d9bb192` (signal: 4,
SIGILL: illegal instruction)
```

The conversion from url::Url to hyper::Uri is a bit cumbersome. I did not find any other way than converting to string and back. Also, I've added a nasty unwrap. This could be handled more gracefully by having a Result as a return type for the queries, but I would say it's fine for now since hyper used this same process internally until url was removed.