### PR TITLE
Await completion of future in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ fn main() {
     ];
 
     let insert = async_db.add_data(&batch); // Returns a Future
+    core.run(insert).expect("Unable to run future to completion");
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 //!     ];
 //!
 //!     let insert = async_db.add_data(&batch); // Returns a Future
+//!     core.run(insert).expect("Unable to run future to completion");
 //! }
 //! ```
 


### PR DESCRIPTION
For a first time user, it's nice to have a "happy moment" when using a new library for the first time. While running the example code from the `README`, I was a bit confused why I couldn't see my data in InfluxDB. Of course the solution was to simply wait for the future to complete.
Do you think it makes sense to add this final line to the example to write the data to InfluxDB when the code is executed?